### PR TITLE
added initial yaw as a reference parameter

### DIFF
--- a/geodetic_utils/parameters/imu_compass.yaml
+++ b/geodetic_utils/parameters/imu_compass.yaml
@@ -24,11 +24,11 @@ mag_bias_3D:
      z_prescale: 0.25
      
      # Bias offset values
-     x_bias: -216.895
-     y_bias: 94.4322
-     z_bias: -108.427
+     x_bias: -180.274
+     y_bias: 75.4214
+     z_bias: -121.783
      
      # Scaling factors
-     x_scale: 0.706948
-     y_scale: 0.719264
-     z_scale: 0.781422
+     x_scale: 0.691561
+     y_scale: 0.713204
+     z_scale: 0.774284

--- a/geodetic_utils/src/imu_compass_asl.cpp
+++ b/geodetic_utils/src/imu_compass_asl.cpp
@@ -309,7 +309,7 @@ void IMUCompass::repackageImuPublish(tf::StampedTransform transform)
 
   //std::cout << "rpy: " << hroll << ", " << hpitch << " ," << hyaw << std::endl;
 
-  tf::Quaternion hackq = tf::createQuaternionFromRPY(hroll, hpitch, -(hyaw+M_PI/2));
+  tf::Quaternion hackq = tf::createQuaternionFromRPY(hroll, hpitch, -(hyaw+M_PI/2.0));
 
   //tf::quaternionTFToMsg(o_imu_reading.getRotation(), curr_imu_reading_->orientation);
   tf::quaternionTFToMsg(hackq, curr_imu_reading_->orientation);

--- a/geodetic_utils/src/imu_compass_asl.cpp
+++ b/geodetic_utils/src/imu_compass_asl.cpp
@@ -302,7 +302,17 @@ void IMUCompass::repackageImuPublish(tf::StampedTransform transform)
   sensor_msgs::Imu publish_imu;
   o_imu_reading = tf::Transform(new_quaternion, tf::Vector3(0, 0, 0));
   o_imu_reading = o_imu_reading * (transform.inverse());
-  tf::quaternionTFToMsg(o_imu_reading.getRotation(), curr_imu_reading_->orientation);
+
+  // TODO: hack, rotate resulting heading measurement
+  double hroll, hpitch, hyaw;
+  tf::Matrix3x3(o_imu_reading.getRotation()).getRPY(hroll, hpitch, hyaw);
+
+  //std::cout << "rpy: " << hroll << ", " << hpitch << " ," << hyaw << std::endl;
+
+  tf::Quaternion hackq = tf::createQuaternionFromRPY(hroll, hpitch, -(hyaw+M_PI/2));
+
+  //tf::quaternionTFToMsg(o_imu_reading.getRotation(), curr_imu_reading_->orientation);
+  tf::quaternionTFToMsg(hackq, curr_imu_reading_->orientation);
 
   // Publish all data
   std_msgs::Float32 curr_heading_float;


### PR DESCRIPTION
We need initial yaw to estimate the alignment between the ENU frame (in which waypoints are specified) and the body frame (in which control commands are given). This adds a parameter for this raw reference averaged using initial yaw measurements. @enricgalceran @fmina 
