### PR TITLE
increased decimal digits when printing info

### DIFF
--- a/src/set_gps_reference_node.cpp
+++ b/src/set_gps_reference_node.cpp
@@ -47,7 +47,7 @@ void gps_callback(const sensor_msgs::NavSatFixConstPtr & msg)
     g_lon_ref += msg->longitude;
     g_alt_ref += msg->altitude;
 
-    ROS_INFO("Current measurement: %f, %f, %f", msg->latitude, msg->longitude, msg->altitude);
+    ROS_INFO("Current measurement: %3.8f, %3.8f, %4.2f", msg->latitude, msg->longitude, msg->altitude);
 
     if (g_count == g_its) {
       if (g_mode == MODE_AVERAGE) {
@@ -66,7 +66,7 @@ void gps_callback(const sensor_msgs::NavSatFixConstPtr & msg)
       nh.setParam("/gps_ref_altitude", g_alt_ref);
       nh.setParam("/gps_ref_is_init", true);
 
-      ROS_INFO("Final reference position: %f, %f, %f", g_lat_ref, g_lon_ref, g_alt_ref);
+      ROS_INFO("Final reference position: %3.8f, %3.8f, %4.2f", g_lat_ref, g_lon_ref, g_alt_ref);
 
       return;
     } else {


### PR DESCRIPTION
Roughly speaking:
Delta_Latitude = 10^-5 causes Delta_North ~= 10 m
Delta:Longitude = 10^-5 causes Delta_East ~= 0.7 m
Therefore, to use the averaged latitude, longitude and altitude to initialize an RTK base station at least 7 decimal digits are required (RTK nominal precision is under 10 centimeters).
@marija-p @raghavkhanna  ... could you please have a look? :)
