### PR TITLE
Remove gdal from package definitions

### DIFF
--- a/geotf/package.xml
+++ b/geotf/package.xml
@@ -20,6 +20,5 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf_conversions</depend>
-  <depend>GDAL</depend>
 
 </package>


### PR DESCRIPTION
**Problem Description**
The `pacakage.xml` specifies `GDAL` as a dependency, which `rosdep` is not able to handle. 

```
ERROR: the following packages/stacks could not have their rosdep keys resolved

to system dependencies:

geotf: Cannot locate rosdep definition for [GDAL]
```

Removing `GDAL` from the package definitions resolves this problem, and the package builds as long as gdal is properly installed in the system. 

This is useful for me, since I am installing package dependencies thorugh rosdep which has a dependency to `geodetic_utils`, but the rosdep is failing from this package. This PR fixes the issue

**Additional Context**
- Fixes https://github.com/ethz-asl/geodetic_utils/issues/41