### PR TITLE
Fix for axis swap problem in GDAL < 3

### DIFF
--- a/geotf/CMakeLists.txt
+++ b/geotf/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} gdal)
 cs_add_executable(demo_node src/demo_node.cc)
 target_link_libraries(demo_node ${PROJECT_NAME})
 
+catkin_add_gtest(geo_tf_test test/test_axis_swaps.cc)
+target_link_libraries(geo_tf_test ${PROJECT_NAME})
 
 cs_install()
 cs_export()

--- a/geotf/include/geotf/geodetic_converter.h
+++ b/geotf/include/geotf/geodetic_converter.h
@@ -7,6 +7,7 @@
 
 #include <gdal/ogr_spatialref.h>
 #include <gdal/cpl_conv.h>
+#include <gdal/gdal_version.h>
 #include <iostream>
 #include <Eigen/Dense>
 #include <boost/optional.hpp>

--- a/geotf/include/geotf/geodetic_converter.h
+++ b/geotf/include/geotf/geodetic_converter.h
@@ -27,6 +27,7 @@ class GeodeticConverter {
   typedef std::pair<std::string, std::string> TransformId;
 
  public:
+   GeodeticConverter();
 
   // Initialize frame definitions from rosparams
   void initFromRosParam(const std::string& prefix = "/geotf");
@@ -50,8 +51,8 @@ class GeodeticConverter {
                          const std::string& gcscode);
 
   // Creates a new ENU Frame with its origin at the given
-  // Location (lon,lat, alt)
-  // Where (lon,lat,alt) are defined w.r.t. WGS84
+  // Location (lat, lon, alt)
+  // Where (lat,lon,alt) are defined w.r.t. WGS84
   bool addFrameByENUOrigin(const std::string& name,
                            double lat,
                            double lon,

--- a/geotf/src/geodetic_converter.cc
+++ b/geotf/src/geodetic_converter.cc
@@ -1,7 +1,7 @@
 #include <geotf/geodetic_converter.h>
 namespace geotf {
 // Initialize frame definitions from rosparams
-void GeodeticConverter::initFromRosParam(const std::string& prefix) {
+void GeodeticConverter::initFromRosParam(const std::string &prefix) {
   GeodeticConverter converter;
   ros::NodeHandle nh;
   if (!nh.ok() || !nh.hasParam(prefix)) {
@@ -11,18 +11,18 @@ void GeodeticConverter::initFromRosParam(const std::string& prefix) {
   XmlRpc::XmlRpcValue yaml_raw_data;
   nh.getParam("/geotf", yaml_raw_data);
 
-  auto& frame_definitions = yaml_raw_data["Frames"];
-  for (auto it = frame_definitions.begin();
-       it != frame_definitions.end(); ++it) {
+  auto &frame_definitions = yaml_raw_data["Frames"];
+  for (auto it = frame_definitions.begin(); it != frame_definitions.end();
+       ++it) {
 
     const std::string frame_name = it->first;
-    auto& xmlnode = it->second;
+    auto &xmlnode = it->second;
 
     std::string frame_type = xmlnode["Type"];
     if (frame_type == "EPSGCode") {
       if (!xmlnode.hasMember("Code")) {
-        ROS_WARN_STREAM("[GeoTF] Ignoring frame " << frame_type
-                                                  << ": EPSGCode needs Code setting.");
+        ROS_WARN_STREAM("[GeoTF] Ignoring frame "
+                        << frame_type << ": EPSGCode needs Code setting.");
         continue;
       }
       int code = xmlnode["Code"];
@@ -30,8 +30,8 @@ void GeodeticConverter::initFromRosParam(const std::string& prefix) {
 
     } else if (frame_type == "GCSCode") {
       if (!xmlnode.hasMember("Code")) {
-        ROS_WARN_STREAM("[GeoTF] Ignoring frame " << frame_type
-                                                  << ": GCSCode needs Code setting.");
+        ROS_WARN_STREAM("[GeoTF] Ignoring frame "
+                        << frame_type << ": GCSCode needs Code setting.");
         continue;
       }
       std::string code = xmlnode["Code"];
@@ -39,8 +39,9 @@ void GeodeticConverter::initFromRosParam(const std::string& prefix) {
 
     } else if (frame_type == "UTM") {
       if (!xmlnode.hasMember("Zone") || !xmlnode.hasMember("Hemisphere")) {
-        ROS_WARN_STREAM("[GeoTF] Ignoring frame " << frame_type
-                                                  << ": UTM needs Zone and Hemisphere setting.");
+        ROS_WARN_STREAM("[GeoTF] Ignoring frame "
+                        << frame_type
+                        << ": UTM needs Zone and Hemisphere setting.");
         continue;
       }
       int zone = xmlnode["Zone"];
@@ -48,10 +49,12 @@ void GeodeticConverter::initFromRosParam(const std::string& prefix) {
       addFrameByUTM(frame_name, zone, hemisphere);
 
     } else if (frame_type == "ENUOrigin") {
-      if (!xmlnode.hasMember("LatOrigin") || !xmlnode.hasMember("LonOrigin")
-          || !xmlnode.hasMember("AltOrigin")) {
-        ROS_WARN_STREAM("[GeoTF] Ignoring frame " << frame_type
-                                                  << ": ENUOrigin needs LatOrigin, LonOrigin and AltOrigin setting.");
+      if (!xmlnode.hasMember("LatOrigin") || !xmlnode.hasMember("LonOrigin") ||
+          !xmlnode.hasMember("AltOrigin")) {
+        ROS_WARN_STREAM(
+            "[GeoTF] Ignoring frame "
+            << frame_type
+            << ": ENUOrigin needs LatOrigin, LonOrigin and AltOrigin setting.");
         continue;
       }
       double latOrigin = xmlnode["LatOrigin"];
@@ -64,14 +67,14 @@ void GeodeticConverter::initFromRosParam(const std::string& prefix) {
 
   // Get TF Mapping
   if (yaml_raw_data.hasMember("TF_Mapping")) {
-    auto& tf_mapping = yaml_raw_data["TF_Mapping"];
+    auto &tf_mapping = yaml_raw_data["TF_Mapping"];
     std::string geo_tf = tf_mapping["GEO_TF"];
     std::string tf = tf_mapping["TF"];
     if (mappings_.count(geo_tf)) {
       tf_mapping_ = std::make_pair(geo_tf, tf);
     } else {
-      ROS_WARN_STREAM("[GeoTF] Invalid Tf connection, frame " << geo_tf
-                                                              << " not defined.");
+      ROS_WARN_STREAM("[GeoTF] Invalid Tf connection, frame "
+                      << geo_tf << " not defined.");
     }
     ROS_INFO_STREAM("[GeoTF] TF connection is " << geo_tf << " = " << tf);
   } else {
@@ -80,13 +83,19 @@ void GeodeticConverter::initFromRosParam(const std::string& prefix) {
 
   listener_ = std::make_shared<tf::TransformListener>();
   broadcaster_ = std::make_shared<tf::TransformBroadcaster>();
+
+  if (GDAL_VERSION_MAJOR < 3) {
+    ROS_INFO_STREAM("Found GDAL Version < 3, performing axis swaps.");
+  } else {
+    ROS_INFO_STREAM("Found GDAL Version >=3, NOT performing axis swaps.");
+  }
 }
 
 // Adds a coordinate frame by its EPSG identifier
 // see https://spatialreference.org/ref/epsg/
 // Example: CH1903+ has epsg id 2056
 //          https://spatialreference.org/ref/epsg/2056/
-bool GeodeticConverter::addFrameByEPSG(const std::string& name, const int& id) {
+bool GeodeticConverter::addFrameByEPSG(const std::string &name, const int &id) {
   if (mappings_.count(name)) {
     return false;
   }
@@ -101,15 +110,14 @@ bool GeodeticConverter::addFrameByEPSG(const std::string& name, const int& id) {
 
   mappings_.insert(std::make_pair(name, spatial_ref));
 
-  ROS_INFO_STREAM("[GeoTF] Added EPSG Code " << id <<
-                                             " as frame " << name);
+  ROS_INFO_STREAM("[GeoTF] Added EPSG Code " << id << " as frame " << name);
   return true;
 }
 
 // Add a coordinate frame by a Geo Coordinate System
 // Prominent example: WGS84
-bool GeodeticConverter::addFrameByGCSCode(const std::string& name,
-                                          const std::string& gcscode) {
+bool GeodeticConverter::addFrameByGCSCode(const std::string &name,
+                                          const std::string &gcscode) {
   if (mappings_.count(name)) {
     return false;
   }
@@ -123,16 +131,14 @@ bool GeodeticConverter::addFrameByGCSCode(const std::string& name,
   }
 
   mappings_.insert(std::make_pair(name, spatial_ref));
-  ROS_INFO_STREAM("[GeoTF] Added GCS Code " << gcscode <<
-                                            " as frame " << name);
+  ROS_INFO_STREAM("[GeoTF] Added GCS Code " << gcscode << " as frame " << name);
   return true;
 }
 
 // Add a frame by UTM Zone
 // zone is the UTM zone (e.g. switzerland is in Zone 32)
 // north is true for northern hemisphere zones.
-bool GeodeticConverter::addFrameByUTM(const std::string& name,
-                                      const uint zone,
+bool GeodeticConverter::addFrameByUTM(const std::string &name, const uint zone,
                                       const bool north) {
 
   // Create Spatial Reference from UTM Zone
@@ -142,9 +148,8 @@ bool GeodeticConverter::addFrameByUTM(const std::string& name,
   spatial_ref->SetUTM(zone, north);
 
   mappings_.insert(std::make_pair(name, spatial_ref));
-  ROS_INFO_STREAM("[GeoTF] Added UTM " << zone << "/"
-                                       << (north ? "N" : "S") <<
-                                       " as frame " << name);
+  ROS_INFO_STREAM("[GeoTF] Added UTM " << zone << "/" << (north ? "N" : "S")
+                                       << " as frame " << name);
   return true;
 }
 
@@ -153,7 +158,7 @@ void GeodeticConverter::writeDebugInfo() const {
 
   for (auto key : mappings_) {
     std::cout << key.first << std::endl;
-    char* pszWKT = NULL;
+    char *pszWKT = NULL;
     key.second->exportToWkt(&pszWKT);
     printf("%s\n", pszWKT);
     CPLFree(pszWKT);
@@ -165,9 +170,8 @@ void GeodeticConverter::writeDebugInfo() const {
 // Creates a new ENU Frame with its origin at the given
 // Location (lat, lon, alt)
 // Where (lon,lat,alt) are defined w.r.t. WGS84
-bool GeodeticConverter::addFrameByENUOrigin(const std::string& name,
-                                            const double lat,
-                                            const double lon,
+bool GeodeticConverter::addFrameByENUOrigin(const std::string &name,
+                                            const double lat, const double lon,
                                             const double alt) {
   // Create Spatial Reference from ENU origin
   auto spatial_ref = std::make_shared<OGRSpatialReference>();
@@ -178,37 +182,35 @@ bool GeodeticConverter::addFrameByENUOrigin(const std::string& name,
 
   altitude_offsets_.insert(std::make_pair(name, alt));
 
-  ROS_INFO_STREAM(
-      "[GeoTF] Added ENUOrigin " << lat << "/" << lon << "/" << alt <<
-                                 " as frame " << name);
+  ROS_INFO_STREAM("[GeoTF] Added ENUOrigin " << lat << "/" << lon << "/" << alt
+                                             << " as frame " << name);
   mappings_.insert(std::make_pair(name, spatial_ref));
   return true;
 }
 
-bool GeodeticConverter::addFrameByWKT(const std::string& name,
-                                      const std::string& wktformat) {
+bool GeodeticConverter::addFrameByWKT(const std::string &name,
+                                      const std::string &wktformat) {
   // Create Spatial Reference from well known code
   auto spatial_ref = std::make_shared<OGRSpatialReference>();
 
-  std::vector<char> mutable_cstr
-      (wktformat.c_str(), wktformat.c_str() + wktformat.size() + 1);
-  char* data = mutable_cstr.data();
+  std::vector<char> mutable_cstr(wktformat.c_str(),
+                                 wktformat.c_str() + wktformat.size() + 1);
+  char *data = mutable_cstr.data();
 
   OGRErr err = spatial_ref->importFromWkt(&data);
-  if( err != OGRERR_NONE){
+  if (err != OGRERR_NONE) {
     std::cout << "ERROR" << err << std::endl;
     return false;
   }
   mappings_.insert(std::make_pair(name, spatial_ref));
 
-  ROS_INFO_STREAM("[GeoTF] Added WKT " << wktformat <<
-                                       " as frame " << name);
+  ROS_INFO_STREAM("[GeoTF] Added WKT " << wktformat << " as frame " << name);
   return true;
 }
 
 // Checks if two geo frames can be converted
-bool GeodeticConverter::canConvert(const std::string& input_frame,
-                                   const std::string& output_frame) {
+bool GeodeticConverter::canConvert(const std::string &input_frame,
+                                   const std::string &output_frame) {
   return checkTransform(input_frame, output_frame);
 }
 
@@ -232,16 +234,14 @@ bool GeodeticConverter::hasFrame(const std::string &name) {
 // Converts Pose from one input_frame to output_frame
 // Both frames are assumed to be geoframes
 // Currently, Attitude is not adjusted.
-bool GeodeticConverter::convert(const std::string& input_frame,
-                                const Eigen::Affine3d& input,
-                                const std::string& output_frame,
-                                Eigen::Affine3d* output) {
+bool GeodeticConverter::convert(const std::string &input_frame,
+                                const Eigen::Affine3d &input,
+                                const std::string &output_frame,
+                                Eigen::Affine3d *output) {
   *output = input;
   Eigen::Vector3d translation = input.translation();
-  bool result = convert(input_frame,
-                        input.translation(),
-                        output_frame,
-                        &translation);
+  bool result =
+      convert(input_frame, input.translation(), output_frame, &translation);
 
   if (!result) {
     return false;
@@ -252,10 +252,10 @@ bool GeodeticConverter::convert(const std::string& input_frame,
 
 // Converts Position from one input_frame to output_frame
 // Both frames are assumed to be geoframes
-bool GeodeticConverter::convert(const std::string& input_frame,
-                                const Eigen::Vector3d& input,
-                                const std::string& output_frame,
-                                Eigen::Vector3d* output) {
+bool GeodeticConverter::convert(const std::string &input_frame,
+                                const Eigen::Vector3d &input,
+                                const std::string &output_frame,
+                                Eigen::Vector3d *output) {
 
   OGRCoordinateTransformationPtr transform;
 
@@ -263,7 +263,7 @@ bool GeodeticConverter::convert(const std::string& input_frame,
     return false;
   }
 
-  //copy data
+  // copy data
   *output = input;
 
   // subtract static offset for input frame if it has one
@@ -275,13 +275,15 @@ bool GeodeticConverter::convert(const std::string& input_frame,
   // We assume that IsGeographic is true for non-ENU systems
   // GDAL default is x = lon, y = lat, but we want it the other way around
   // GDAL default for enu is x=e, y= n, which we do not want to switch
-  if (transform->GetSourceCS()->IsGeographic()) {
+  // This changed in GDAL >=3, so swap is only needed for older versions.
+  bool swap_needed =
+      transform->GetSourceCS()->IsGeographic() && (GDAL_VERSION_MAJOR < 3);
+
+  if (swap_needed) {
     std::swap(output->x(), output->y());
   }
 
-  bool transformed = transform->Transform(1,
-                                          output->data(),
-                                          output->data() + 1,
+  bool transformed = transform->Transform(1, output->data(), output->data() + 1,
                                           output->data() + 2);
 
   if (!transformed) {
@@ -289,7 +291,7 @@ bool GeodeticConverter::convert(const std::string& input_frame,
   }
 
   // reverse switch if necessary
-  if (transform->GetTargetCS()->IsGeographic()) {
+  if (swap_needed) {
     std::swap(output->x(), output->y());
   }
   // add static offset for output frame if it has one
@@ -301,11 +303,11 @@ bool GeodeticConverter::convert(const std::string& input_frame,
 }
 
 // Converts a Pose in a geoframe to a pose in a tf frame
-bool GeodeticConverter::convertToTf(const std::string& geo_input_frame,
-                                    const Eigen::Affine3d& input,
-                                    const std::string& tf_output_frame,
-                                    Eigen::Affine3d* output,
-                                    const ros::Time& time) {
+bool GeodeticConverter::convertToTf(const std::string &geo_input_frame,
+                                    const Eigen::Affine3d &input,
+                                    const std::string &tf_output_frame,
+                                    Eigen::Affine3d *output,
+                                    const ros::Time &time) {
   if (!tf_mapping_) {
     ROS_WARN("[GeoTf] No TF mapping defined, canceling convertToTf");
     return false;
@@ -316,12 +318,12 @@ bool GeodeticConverter::convertToTf(const std::string& geo_input_frame,
   Eigen::Affine3d tf_connection_value;
 
   // Convert from whatever geo frame to geotf_connection_frame
-  bool result = convert(geo_input_frame,
-                        input,
-                        geotf_connection_frame,
+  bool result = convert(geo_input_frame, input, geotf_connection_frame,
                         &tf_connection_value);
 
-  if (!result) { return false; }
+  if (!result) {
+    return false;
+  }
 
   // Convert from tf_connection_frame to tf_output_frame.
   if (!listener_->canTransform(tf_output_frame, tf_connection_frame, time)) {
@@ -331,10 +333,9 @@ bool GeodeticConverter::convertToTf(const std::string& geo_input_frame,
   tf::StampedTransform tf_T_O_C; // transform connection to output.
   Eigen::Affine3d eigen_T_O_C;
   try {
-    listener_->lookupTransform(tf_output_frame,
-                               tf_connection_frame,
-                               time, tf_T_O_C);
-  } catch (std::exception& ex) {
+    listener_->lookupTransform(tf_output_frame, tf_connection_frame, time,
+                               tf_T_O_C);
+  } catch (std::exception &ex) {
     ROS_WARN_STREAM("[GeoTF] Error in tf connection" << ex.what());
     return false;
   }
@@ -346,18 +347,18 @@ bool GeodeticConverter::convertToTf(const std::string& geo_input_frame,
 }
 
 // Publishes a geolocation as a tf frame
-bool GeodeticConverter::publishAsTf(const std::string& geo_input_frame,
-                                    const Eigen::Vector3d& input,
-                                    const std::string& frame_name) {
+bool GeodeticConverter::publishAsTf(const std::string &geo_input_frame,
+                                    const Eigen::Vector3d &input,
+                                    const std::string &frame_name) {
   Eigen::Affine3d affine(Eigen::Affine3d::Identity());
   affine.translation() = input;
   return publishAsTf(geo_input_frame, affine, frame_name);
 }
 
 // Publishes a geolocation as a tf frame
-bool GeodeticConverter::publishAsTf(const std::string& geo_input_frame,
-                                    const Eigen::Affine3d& input,
-                                    const std::string& frame_name) {
+bool GeodeticConverter::publishAsTf(const std::string &geo_input_frame,
+                                    const Eigen::Affine3d &input,
+                                    const std::string &frame_name) {
   if (!tf_mapping_) {
     ROS_WARN("[GeoTf] No TF mapping defined, canceling convertAsTf");
     return false;
@@ -367,9 +368,7 @@ bool GeodeticConverter::publishAsTf(const std::string& geo_input_frame,
   std::string geotf_connection_frame = tf_mapping_->first;
 
   Eigen::Affine3d input_connection;
-  bool result = convert(geo_input_frame,
-                        input,
-                        geotf_connection_frame,
+  bool result = convert(geo_input_frame, input, geotf_connection_frame,
                         &input_connection);
 
   if (!result) {
@@ -386,36 +385,34 @@ bool GeodeticConverter::publishAsTf(const std::string& geo_input_frame,
 }
 
 // Convets a Pose in a TF to a pose in a Geo frame
-bool GeodeticConverter::convertFromTf(const std::string& tf_input_frame,
-                                      const Eigen::Affine3d& input,
-                                      const std::string& geo_output_frame,
-                                      Eigen::Affine3d* output,
-                                      const ros::Time& time) {
+bool GeodeticConverter::convertFromTf(const std::string &tf_input_frame,
+                                      const Eigen::Affine3d &input,
+                                      const std::string &geo_output_frame,
+                                      Eigen::Affine3d *output,
+                                      const ros::Time &time) {
   if (!tf_mapping_) {
     ROS_WARN("[GeoTf] No TF mapping defined, canceling convertFromTf");
     return false;
   }
 
   Eigen::Affine3d tf_connection_value;
-  //convert from tf input to
+  // convert from tf input to
   std::string tf_connection_frame = tf_mapping_->second;
   std::string geotf_connection_frame = tf_mapping_->first;
 
-  //Convert from tf_input_frame  to tf_connection_frame
+  // Convert from tf_input_frame  to tf_connection_frame
   if (!listener_->canTransform(tf_connection_frame, tf_input_frame, time)) {
     return false;
   }
-
 
   // add exception handling etc.
   tf::StampedTransform tf_T_C_I; // transform input to connection
   Eigen::Affine3d eigen_T_C_I;
 
   try {
-    listener_->lookupTransform(tf_connection_frame,
-                               tf_input_frame,
-                               time, tf_T_C_I);
-  } catch (std::exception& ex) {
+    listener_->lookupTransform(tf_connection_frame, tf_input_frame, time,
+                               tf_T_C_I);
+  } catch (std::exception &ex) {
     ROS_WARN_STREAM("[GeoTF] Error in tf connection" << ex.what());
     return false;
   }
@@ -424,16 +421,13 @@ bool GeodeticConverter::convertFromTf(const std::string& tf_input_frame,
   tf_connection_value = eigen_T_C_I * input;
 
   // convert from corresponding
-  return convert(geotf_connection_frame,
-                 tf_connection_value,
-                 geo_output_frame,
+  return convert(geotf_connection_frame, tf_connection_value, geo_output_frame,
                  output);
-
 }
 
-bool GeodeticConverter::getTransform(const std::string& input_frame,
-                                     const std::string& output_frame,
-                                     OGRCoordinateTransformationPtr* transform) {
+bool GeodeticConverter::getTransform(
+    const std::string &input_frame, const std::string &output_frame,
+    OGRCoordinateTransformationPtr *transform) {
   if (!checkTransform(input_frame, output_frame)) {
     return false;
   }
@@ -442,8 +436,8 @@ bool GeodeticConverter::getTransform(const std::string& input_frame,
   return true;
 }
 
-bool GeodeticConverter::checkTransform(const std::string& input_frame,
-                                       const std::string& output_frame) {
+bool GeodeticConverter::checkTransform(const std::string &input_frame,
+                                       const std::string &output_frame) {
   TransformId tf_id = std::make_pair(input_frame, output_frame);
 
   // Check if we already cached transform
@@ -457,9 +451,8 @@ bool GeodeticConverter::checkTransform(const std::string& input_frame,
   }
 
   // Create transform
-  OGRCoordinateTransformationPtr transform
-      (OGRCreateCoordinateTransformation(mappings_.at(tf_id.first).get(),
-                                         mappings_.at(tf_id.second).get()));
+  OGRCoordinateTransformationPtr transform(OGRCreateCoordinateTransformation(
+      mappings_.at(tf_id.first).get(), mappings_.at(tf_id.second).get()));
 
   // if invalid
   if (transform.get() == nullptr) {
@@ -470,4 +463,4 @@ bool GeodeticConverter::checkTransform(const std::string& input_frame,
   transforms_.insert(std::make_pair(tf_id, transform));
   return true;
 }
-}
+} // namespace geotf

--- a/geotf/test/test_axis_swaps.cc
+++ b/geotf/test/test_axis_swaps.cc
@@ -1,0 +1,26 @@
+#include <geotf/geodetic_converter.h>
+#include <gtest/gtest.h>
+
+TEST(AxisSwapTest, UTMtoGPS) {
+  geotf::GeodeticConverter converter;
+  converter.addFrameByUTM("UTM", 32, true);
+  converter.addFrameByGCSCode("GPS", "WGS84");
+
+  // values obtained independently from swiss map.
+  const Eigen::Vector3d gps_pos(46.34019, 9.15765, 2632.7);
+  const Eigen::Vector3d utm_pos(512132, 5131858, 2632.7); // E N U
+
+  Eigen::Vector3d utm_pos_converted;
+  converter.convert("GPS", gps_pos, "UTM", &utm_pos_converted);
+
+  // round for pos x and y is valid because we only have the original coordinate
+  // to the meter from the map.
+  ASSERT_EQ(round(utm_pos.x()), round(utm_pos_converted.x()));
+  ASSERT_EQ(round(utm_pos.y()), round(utm_pos_converted.y()));
+  ASSERT_EQ(utm_pos.z(), utm_pos_converted.z());
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Problem: In GDAL > 3, the axis order has been reversed. See https://gdal.org/tutorials/osr_api_tut.html
- Fixed by detecting gdal version, and performing axis swaps only for older (below 3) versions