### PR TITLE
Specified package from which to import the compiled code into python

### DIFF
--- a/geotf_python/python/geotf/__init__.py
+++ b/geotf_python/python/geotf/__init__.py
@@ -1,2 +1,2 @@
 import numpy_eigen
-from libgeotf_python import *
+from geotf.libgeotf_python import *


### PR DESCRIPTION
After building the geotf_python package, the python import doesn't work, because the compiled geotf library cannot be found. Specifying the location of the libgeotf_python file fixes this issue